### PR TITLE
Provide a filename slug for stat files [Delivers #90136738]

### DIFF
--- a/docs/bws_rotated_files.3
+++ b/docs/bws_rotated_files.3
@@ -44,6 +44,18 @@ void
 .PD
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ unsigned
 int \f[I]minutes\f[]);
+.PP
+void
+.PD 0
+.P
+.PD
+\f[B]bws_rotated_files_set_filename_slug\f[](struct bws_rotated_files
+*\f[I]rotated\f[],
+.PD 0
+.P
+.PD
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ const
+char *\f[I]slug\f[]);
 .SH DESCRIPTION
 .PP
 A \f[B]bws_rotated_files\f[] instance is a specialized
@@ -56,7 +68,11 @@ files; that is your responsibility.)
 .PP
 All of the files written will have names of the following form:
 .PP
-stats\-\f[I]YYYYMMDD\f[]\-\f[I]HHMMSS\f[].log
+stats\-\f[I]slug\f[]\-\f[I]YYYYMMDD\f[]\-\f[I]HHMMSS\f[].log
+.PP
+The \f[I]slug\f[] portion is optional; if you don't call
+\f[B]bws_rotated_files_set_filename_slug\f[](), then the filenames will
+not include any slug.
 .PP
 The \[lq]current\[rq] file will be written to a temporary file in the
 same output directory; when the file is closed (either because of a
@@ -86,6 +102,11 @@ if necessary.
 long each file should be \[lq]current\[rq] before we rotate over into a
 new file.
 The default duration is 10 minutes.
+.PP
+\f[B]bws_rotated_files_set_filename_slug\f[]() lets you provide a
+\f[I]slug\f[] that will be included in each output filename.
+This lets you write statistics from several processes into the same
+directory, while easily being able to tell them apart.
 .SH RETURN VALUES
 .PP
 \f[B]bws_rotated_files_new\f[]() always returns a valid new file

--- a/docs/bws_rotated_files.3.pandoc
+++ b/docs/bws_rotated_files.3.pandoc
@@ -23,6 +23,10 @@ bws_rotated_files -- Writing statistics into rotated files
 | void
 | **bws_rotated_files_set_file_duration**(struct bws_rotated_files \**rotated*,
 |                                     unsigned int *minutes*);
+|
+| void
+| **bws_rotated_files_set_filename_slug**(struct bws_rotated_files \**rotated*,
+|                                     const char \**slug*);
 
 
 # DESCRIPTION
@@ -36,7 +40,11 @@ responsibility.)
 
 All of the files written will have names of the following form:
 
-| stats-*YYYYMMDD*-*HHMMSS*.log
+| stats-*slug*-*YYYYMMDD*-*HHMMSS*.log
+
+The *slug* portion is optional; if you don't call
+**bws_rotated_files_set_filename_slug**(), then the filenames will not include
+any slug.
 
 The "current" file will be written to a temporary file in the same output
 directory; when the file is closed (either because of a rotation or because the
@@ -61,6 +69,10 @@ into a new file if necessary.
 **bws_rotated_files_set_file_duration**() lets you configure how long each file
 should be "current" before we rotate over into a new file.  The default duration
 is 10 minutes.
+
+**bws_rotated_files_set_filename_slug**() lets you provide a *slug* that will be
+included in each output filename.  This lets you write statistics from several
+processes into the same directory, while easily being able to tell them apart.
 
 
 # RETURN VALUES

--- a/docs/links/bws_rotated_files_set_filename_slug.3
+++ b/docs/links/bws_rotated_files_set_filename_slug.3
@@ -1,0 +1,1 @@
+.so man3/bws_rotated_files.3

--- a/include/bowsprit.h
+++ b/include/bowsprit.h
@@ -323,5 +323,9 @@ void
 bws_rotated_files_set_file_duration(struct bws_rotated_files *rotated,
                                     unsigned int minutes);
 
+void
+bws_rotated_files_set_filename_slug(struct bws_rotated_files *rotated,
+                                    const char *slug);
+
 
 #endif /* BOWSPRIT_H */

--- a/tests/rotated-files.t
+++ b/tests/rotated-files.t
@@ -30,3 +30,23 @@ variety of test cases.  But this works fine for now.
   4              test-1/dog
   5    0.033  /s test-1/cat
   3              test-1/frog
+  
+  ./stats-slugged-20140101-000000.log
+  === Statistics of as of 2014-01-01 00:00:00
+  0              test-1/dog
+  0              test-1/cat
+  0              test-1/frog
+  === Statistics of as of 2014-01-01 00:00:30
+  1              test-1/dog
+  2    0.067  /s test-1/cat
+  1              test-1/frog
+  
+  ./stats-slugged-20140101-000100.log
+  === Statistics of as of 2014-01-01 00:01:00
+  2              test-1/dog
+  4    0.067  /s test-1/cat
+  2              test-1/frog
+  === Statistics of as of 2014-01-01 00:01:30
+  4              test-1/dog
+  5    0.033  /s test-1/cat
+  3              test-1/frog


### PR DESCRIPTION
We provide the ability to add slug values to fathom-sensor data files,
so we should do the same for our stats files.  It makes it much easier
to track and correlate them across customes and time.

This patch provides a setter method for a filename slug.  The slug value
is placed between the "stats" and timestamp substrings in the filename.