### PR TITLE
Enable static libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /build/
 /.build/
 
-RELEASE-VERSION
 bowsprit.pc
 
 /bowsprit*.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,24 +12,49 @@ set(RELEASE_DATE 2015-03-12)
 project(${PROJECT_NAME})
 enable_testing()
 
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+find_package(ParseArguments)
+find_package(Prereqs)
+find_package(CTargets)
+
 #-----------------------------------------------------------------------
 # Retrieve the current version number
 
-execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/version.sh
+execute_process(
+    COMMAND git describe
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE VERSION_RESULT
     OUTPUT_VARIABLE VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 if(VERSION_RESULT)
     message(FATAL_ERROR
             "Cannot determine version number: " ${VERSION_RESULT})
 endif(VERSION_RESULT)
-# This causes an annoying extra prompt in ccmake.
-# message("Current version: " ${VERSION})
+message(STATUS "Current version: " ${VERSION})
 
 string(REGEX REPLACE "-dev.*" "-dev" BASE_VERSION "${VERSION}")
 
-find_package(PkgConfig)
+if(BASE_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+    set(VERSION_MAJOR "${CMAKE_MATCH_1}")
+    set(VERSION_MINOR "${CMAKE_MATCH_2}")
+    set(VERSION_PATCH "${CMAKE_MATCH_3}")
+else(BASE_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+    message(FATAL_ERROR "Invalid version number: ${VERSION}")
+endif(BASE_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+
+execute_process(
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE GIT_SHA1_RESULT
+    OUTPUT_VARIABLE GIT_SHA1
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(GIT_SHA1_RESULT)
+    message(FATAL_ERROR
+            "Cannot determine git commit: " ${GIT_SHA1_RESULT})
+endif(GIT_SHA1_RESULT)
+message(STATUS "Current revision: " ${GIT_SHA1})
 
 #-----------------------------------------------------------------------
 # Check for building on Tilera
@@ -56,17 +81,6 @@ if(DEFINED ENV{TILERA_ROOT})
 endif()
 
 #-----------------------------------------------------------------------
-# Check for prerequisite libraries
-
-pkg_check_modules(CORK REQUIRED libcork>=0.14.0)
-include_directories(${CORK_INCLUDE_DIRS})
-link_directories(${CORK_LIBRARY_DIRS})
-
-pkg_check_modules(CLOG REQUIRED clogger>=0.3.0)
-include_directories(${CLOG_INCLUDE_DIRS})
-link_directories(${CLOG_LIBRARY_DIRS})
-
-#-----------------------------------------------------------------------
 # Set some options
 
 if(APPLE)
@@ -91,6 +105,12 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang")
 elseif(CMAKE_C_COMPILER_ID STREQUAL "Intel")
     add_definitions(-Wall -Werror)
 endif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+
+#-----------------------------------------------------------------------
+# Check for prerequisite libraries
+
+pkgconfig_prereq(libcork>=0.14.0)
+pkgconfig_prereq(clogger>=0.3.0)
 
 #-----------------------------------------------------------------------
 # Include our subdirectories

--- a/cmake/FindCTargets.cmake
+++ b/cmake/FindCTargets.cmake
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------
+# Copyright © 2015, RedJack, LLC.
+# All rights reserved.
+#
+# Please see the COPYING file in this distribution for license details.
+# ----------------------------------------------------------------------
+
+
+#-----------------------------------------------------------------------
+# Configuration options that control all of the below
+
+set(ENABLE_SHARED YES CACHE BOOL "Whether to build a shared library")
+set(ENABLE_SHARED_EXECUTABLES YES CACHE BOOL
+    "Whether to link executables using shared libraries")
+set(ENABLE_STATIC YES CACHE BOOL "Whether to build a static library")
+
+
+#-----------------------------------------------------------------------
+# Library, with options to build both shared and static versions
+
+function(target_add_shared_libraries TARGET_NAME LIBRARIES LOCAL_LIBRARIES)
+    foreach(lib ${LIBRARIES})
+        string(REPLACE "-" "_" lib ${lib})
+        string(TOUPPER ${lib} upperlib)
+        target_link_libraries(
+            ${TARGET_NAME}
+            ${${upperlib}_LDFLAGS}
+        )
+    endforeach(lib)
+    foreach(lib ${LOCAL_LIBRARIES})
+        target_link_libraries(${TARGET_NAME} ${lib}-shared)
+    endforeach(lib)
+endfunction(target_add_shared_libraries)
+
+function(target_add_static_libraries TARGET_NAME LIBRARIES LOCAL_LIBRARIES)
+    foreach(lib ${LIBRARIES})
+        string(REPLACE "-" "_" lib ${lib})
+        string(TOUPPER ${lib} upperlib)
+        target_link_libraries(
+            ${TARGET_NAME}
+            ${${upperlib}_STATIC_LDFLAGS}
+        )
+    endforeach(lib)
+    foreach(lib ${LOCAL_LIBRARIES})
+        target_link_libraries(${TARGET_NAME} ${lib}-static)
+    endforeach(lib)
+endfunction(target_add_static_libraries)
+
+set_property(GLOBAL PROPERTY ALL_LOCAL_LIBRARIES "")
+
+function(add_c_library __TARGET_NAME)
+    set(options)
+    set(one_args OUTPUT_NAME PKGCONFIG_NAME VERSION)
+    set(multi_args LIBRARIES LOCAL_LIBRARIES SOURCES)
+    cmake_parse_arguments(_ "${options}" "${one_args}" "${multi_args}" ${ARGN})
+
+    if (__VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+        set(__VERSION_CURRENT  "${CMAKE_MATCH_1}")
+        set(__VERSION_REVISION "${CMAKE_MATCH_2}")
+        set(__VERSION_AGE      "${CMAKE_MATCH_3}")
+    else (__VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+        message(FATAL_ERROR "Invalid library version number: ${__VERSION}")
+    endif (__VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+
+    math(EXPR __SOVERSION "${__VERSION_CURRENT} - ${__VERSION_AGE}")
+
+    get_property(ALL_LOCAL_LIBRARIES GLOBAL PROPERTY ALL_LOCAL_LIBRARIES)
+    list(APPEND ALL_LOCAL_LIBRARIES ${__TARGET_NAME})
+    set_property(GLOBAL PROPERTY ALL_LOCAL_LIBRARIES "${ALL_LOCAL_LIBRARIES}")
+
+    if (ENABLE_SHARED OR ENABLE_SHARED_EXECUTABLES)
+        add_library(${__TARGET_NAME}-shared SHARED ${__SOURCES})
+        set_target_properties(
+            ${__TARGET_NAME}-shared PROPERTIES
+            OUTPUT_NAME ${__OUTPUT_NAME}
+            CLEAN_DIRECT_OUTPUT 1
+            VERSION ${__VERSION}
+            SOVERSION ${__SOVERSION}
+        )
+
+        if (CMAKE_VERSION VERSION_GREATER "2.8.11")
+            target_include_directories(
+                ${__TARGET_NAME}-shared PUBLIC
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_BINARY_DIR}/include
+            )
+        else (CMAKE_VERSION VERSION_GREATER "2.8.11")
+            include_directories(
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_BINARY_DIR}/include
+            )
+        endif (CMAKE_VERSION VERSION_GREATER "2.8.11")
+
+        target_add_shared_libraries(
+            ${__TARGET_NAME}-shared
+            "${__LIBRARIES}"
+            "${__LOCAL_LIBRARIES}"
+        )
+
+        # We have to install the shared library if the user asked us to, or if
+        # the user asked us to link our programs with the shared library.
+        install(TARGETS ${__TARGET_NAME}-shared
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    endif (ENABLE_SHARED OR ENABLE_SHARED_EXECUTABLES)
+
+    if (ENABLE_STATIC OR NOT ENABLE_SHARED_EXECUTABLES)
+        add_library(${__TARGET_NAME}-static STATIC ${__SOURCES})
+        set_target_properties(
+            ${__TARGET_NAME}-static PROPERTIES
+            OUTPUT_NAME ${__OUTPUT_NAME}
+            CLEAN_DIRECT_OUTPUT 1
+        )
+
+        if (CMAKE_VERSION VERSION_GREATER "2.8.11")
+            target_include_directories(
+                ${__TARGET_NAME}-static PUBLIC
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_BINARY_DIR}/include
+            )
+        else (CMAKE_VERSION VERSION_GREATER "2.8.11")
+            include_directories(
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_BINARY_DIR}/include
+            )
+        endif (CMAKE_VERSION VERSION_GREATER "2.8.11")
+
+        target_add_static_libraries(
+            ${__TARGET_NAME}-static
+            "${__LIBRARIES}"
+            "${__LOCAL_LIBRARIES}"
+        )
+    endif (ENABLE_STATIC OR NOT ENABLE_SHARED_EXECUTABLES)
+
+    if (ENABLE_STATIC)
+        # We DON'T have to install the static library if the user asked us to
+        # link our programs statically.
+        install(TARGETS ${__TARGET_NAME}-static
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    endif (ENABLE_STATIC)
+
+    set(prefix ${CMAKE_INSTALL_PREFIX})
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/${__PKGCONFIG_NAME}.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${__PKGCONFIG_NAME}.pc
+        @ONLY
+    )
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/${__PKGCONFIG_NAME}.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+endfunction(add_c_library)
+
+
+#-----------------------------------------------------------------------
+# Executable
+
+function(add_c_executable __TARGET_NAME)
+    set(options SKIP_INSTALL)
+    set(one_args OUTPUT_NAME)
+    set(multi_args LIBRARIES LOCAL_LIBRARIES SOURCES)
+    cmake_parse_arguments(_ "${options}" "${one_args}" "${multi_args}" ${ARGN})
+
+    add_executable(${__TARGET_NAME} ${__SOURCES})
+
+    if (CMAKE_VERSION VERSION_GREATER "2.8.11")
+        target_include_directories(
+            ${__TARGET_NAME} PUBLIC
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_BINARY_DIR}/include
+        )
+    else (CMAKE_VERSION VERSION_GREATER "2.8.11")
+        include_directories(
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_BINARY_DIR}/include
+        )
+    endif (CMAKE_VERSION VERSION_GREATER "2.8.11")
+
+    if (ENABLE_SHARED_EXECUTABLES)
+        target_add_shared_libraries(
+            ${__TARGET_NAME}
+            "${__LIBRARIES}"
+            "${__LOCAL_LIBRARIES}"
+        )
+    else (ENABLE_SHARED_EXECUTABLES)
+        target_add_static_libraries(
+            ${__TARGET_NAME}
+            "${__LIBRARIES}"
+            "${__LOCAL_LIBRARIES}"
+        )
+    endif (ENABLE_SHARED_EXECUTABLES)
+
+    if (NOT __SKIP_INSTALL)
+        install(TARGETS ${__TARGET_NAME} RUNTIME DESTINATION bin)
+    endif (NOT __SKIP_INSTALL)
+endfunction(add_c_executable)
+
+
+#-----------------------------------------------------------------------
+# Test case
+
+pkgconfig_prereq(check OPTIONAL)
+
+function(add_c_test TEST_NAME)
+    get_property(ALL_LOCAL_LIBRARIES GLOBAL PROPERTY ALL_LOCAL_LIBRARIES)
+    add_c_executable(
+        ${TEST_NAME}
+        SKIP_INSTALL
+        OUTPUT_NAME ${TEST_NAME}
+        SOURCES ${TEST_NAME}.c
+        LIBRARIES check
+        LOCAL_LIBRARIES ${ALL_LOCAL_LIBRARIES}
+    )
+    add_test(${TEST_NAME} ${TEST_NAME})
+endfunction(add_c_test)

--- a/cmake/FindParseArguments.cmake
+++ b/cmake/FindParseArguments.cmake
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------
+# Copyright © 2015, RedJack, LLC.
+# All rights reserved.
+#
+# Please see the COPYING file in this distribution for license details.
+# ----------------------------------------------------------------------
+
+
+# CMake 2.8.4 and higher gives us cmake_parse_arguments out of the box.  For
+# earlier versions (RHEL5!) we have to define it ourselves.  (The definition
+# comes from <http://www.cmake.org/Wiki/CMakeMacroParseArguments>.)
+
+if (CMAKE_VERSION VERSION_LESS "2.8.4")
+
+MACRO(CMAKE_PARSE_ARGUMENTS prefix arg_names option_names)
+  SET(DEFAULT_ARGS)
+  FOREACH(arg_name ${arg_names})
+    SET(${prefix}_${arg_name})
+  ENDFOREACH(arg_name)
+  FOREACH(option ${option_names})
+    SET(${prefix}_${option} FALSE)
+  ENDFOREACH(option)
+
+  SET(current_arg_name DEFAULT_ARGS)
+  SET(current_arg_list)
+  FOREACH(arg ${ARGN})
+    SET(larg_names ${arg_names})
+    LIST(FIND larg_names "${arg}" is_arg_name)
+    IF (is_arg_name GREATER -1)
+      SET(${prefix}_${current_arg_name} ${current_arg_list})
+      SET(current_arg_name ${arg})
+      SET(current_arg_list)
+    ELSE (is_arg_name GREATER -1)
+      SET(loption_names ${option_names})
+      LIST(FIND loption_names "${arg}" is_option)
+      IF (is_option GREATER -1)
+          SET(${prefix}_${arg} TRUE)
+      ELSE (is_option GREATER -1)
+          SET(current_arg_list ${current_arg_list} ${arg})
+      ENDIF (is_option GREATER -1)
+    ENDIF (is_arg_name GREATER -1)
+  ENDFOREACH(arg)
+  SET(${prefix}_${current_arg_name} ${current_arg_list})
+ENDMACRO(CMAKE_PARSE_ARGUMENTS)
+
+else (CMAKE_VERSION VERSION_LESS "2.8.4")
+
+    include(CMakeParseArguments)
+
+endif (CMAKE_VERSION VERSION_LESS "2.8.4")

--- a/cmake/FindPrereqs.cmake
+++ b/cmake/FindPrereqs.cmake
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------
+# Copyright © 2015, RedJack, LLC.
+# All rights reserved.
+#
+# Please see the COPYING file in this distribution for license details.
+# ----------------------------------------------------------------------
+
+
+#-----------------------------------------------------------------------
+# Configuration options that control all of the below
+
+set(PKG_CONFIG_PATH CACHE STRING "pkg-config search path")
+if (PKG_CONFIG_PATH)
+    set(ENV{PKG_CONFIG_PATH} "${PKG_CONFIG_PATH}:$ENV{PKG_CONFIG_PATH}")
+endif (PKG_CONFIG_PATH)
+
+
+#-----------------------------------------------------------------------
+# pkg-config prerequisites
+
+find_package(PkgConfig)
+
+function(pkgconfig_prereq DEP)
+    set(options OPTIONAL)
+    set(one_args)
+    set(multi_args)
+    cmake_parse_arguments(_ "${options}" "${one_args}" "${multi_args}" ${ARGN})
+
+    string(REGEX REPLACE "[<>=].*" "" SHORT_NAME "${DEP}")
+    string(REPLACE "-" "_" SHORT_NAME "${SHORT_NAME}")
+    string(TOUPPER ${SHORT_NAME} UPPER_SHORT_NAME)
+    string(TOLOWER ${SHORT_NAME} LOWER_SHORT_NAME)
+
+    set(USE_CUSTOM_${UPPER_SHORT_NAME} NO CACHE BOOL
+        "Whether you want to provide custom details for ${LOWER_SHORT_NAME}")
+
+    if (NOT USE_CUSTOM_${UPPER_SHORT_NAME})
+        set(PKG_CHECK_ARGS)
+        if (NOT __OPTIONAL)
+            list(APPEND PKG_CHECK_ARGS REQUIRED)
+        endif (NOT __OPTIONAL)
+        list(APPEND PKG_CHECK_ARGS ${DEP})
+
+        pkg_check_modules(${UPPER_SHORT_NAME} ${PKG_CHECK_ARGS})
+    endif (NOT USE_CUSTOM_${UPPER_SHORT_NAME})
+
+    include_directories(${${UPPER_SHORT_NAME}_INCLUDE_DIRS})
+    link_directories(${${UPPER_SHORT_NAME}_LIBRARY_DIRS})
+endfunction(pkgconfig_prereq)
+
+
+#-----------------------------------------------------------------------
+# find_library prerequisites
+
+function(library_prereq LIB_NAME)
+    set(options OPTIONAL)
+    set(one_args)
+    set(multi_args)
+    cmake_parse_arguments(_ "${options}" "${one_args}" "${multi_args}" ${ARGN})
+
+    string(REPLACE "-" "_" SHORT_NAME "${LIB_NAME}")
+    string(TOUPPER ${SHORT_NAME} UPPER_SHORT_NAME)
+    string(TOLOWER ${SHORT_NAME} LOWER_SHORT_NAME)
+
+    set(USE_CUSTOM_${UPPER_SHORT_NAME} NO CACHE BOOL
+        "Whether you want to provide custom details for ${LOWER_SHORT_NAME}")
+
+    if (USE_CUSTOM_${UPPER_SHORT_NAME})
+        include_directories(${${UPPER_SHORT_NAME}_INCLUDE_DIRS})
+        link_directories(${${UPPER_SHORT_NAME}_LIBRARY_DIRS})
+    else (USE_CUSTOM_${UPPER_SHORT_NAME})
+        find_library(${UPPER_SHORT_NAME}_LIBRARIES ${LIB_NAME})
+    endif (USE_CUSTOM_${UPPER_SHORT_NAME})
+
+endfunction(library_prereq)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,22 +6,11 @@
 # Please see the COPYING file in this distribution for license details.
 # ----------------------------------------------------------------------
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
-
 #-----------------------------------------------------------------------
-# Build the library
+# libbowsprit
 
-set(LIBBOWSPRIT_SRC
-    libbowsprit/logger.c
-    libbowsprit/periodic.c
-    libbowsprit/render.c
-    libbowsprit/rotated-files.c
-    libbowsprit/snapshot.c
-    libbowsprit/stats.c
-)
-
-# Update the VERSION and SOVERSION properties below according to the following
-# rules (taken from [1]):
+# Update the VERSION property below according to the following rules (taken from
+# [1]):
 #
 # VERSION = current.revision.age
 #
@@ -38,40 +27,36 @@ set(LIBBOWSPRIT_SRC
 #   6. If any interfaces have been removed or changed since the last public
 #      release, then set `age` to 0.
 #
-# SOVERSION should always equal `current-age`.
-#
 # Note that changing `current` means that you are releasing a new
 # backwards-incompatible version of the library.  This has implications on
-# packaging, so once an API has stabilized, these should be a rare occurrence.
+# packaging, so once an API has stabilized, this should be a rare occurrence.
 #
 # [1] http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html#Updating-version-info
 
-add_library(libbowsprit SHARED ${LIBBOWSPRIT_SRC})
-set_target_properties(libbowsprit PROPERTIES
+add_c_library(
+    libbowsprit
     OUTPUT_NAME bowsprit
+    PKGCONFIG_NAME bowsprit
     VERSION 3.0.1
-    SOVERSION 2)
-target_link_libraries(libbowsprit
-    ${CORK_LIBRARIES}
-    ${CLOG_LIBRARIES}
+    SOURCES
+        libbowsprit/logger.c
+        libbowsprit/periodic.c
+        libbowsprit/render.c
+        libbowsprit/rotated-files.c
+        libbowsprit/snapshot.c
+        libbowsprit/stats.c
+    LIBRARIES
+        libcork
+        clogger
 )
-
-install(TARGETS libbowsprit DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 #-----------------------------------------------------------------------
 # bowsprit-test
 
-set(BOWSPRIT_TEST_SRC
-    bowsprit-test/bowsprit-test.c
+add_c_executable(
+    bowsprit-test
+    SKIP_INSTALL
+    OUTPUT_NAME bowsprit-test
+    SOURCES bowsprit-test/bowsprit-test.c
+    LOCAL_LIBRARIES libbowsprit
 )
-
-add_executable(bowsprit-test ${BOWSPRIT_TEST_SRC})
-target_link_libraries(bowsprit-test libbowsprit)
-
-#-----------------------------------------------------------------------
-# Generate the pkg-config file
-
-set(prefix ${CMAKE_INSTALL_PREFIX})
-configure_file(bowsprit.pc.in ${CMAKE_CURRENT_BINARY_DIR}/bowsprit.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bowsprit.pc
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,29 +6,11 @@
 # Please see the COPYING file in this distribution for license details.
 # ----------------------------------------------------------------------
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_BINARY_DIR}/src)
-
-#-----------------------------------------------------------------------
-# Check for prerequisite libraries
-
-find_package(PkgConfig)
-
-pkg_check_modules(CHECK REQUIRED check)
-include_directories(${CHECK_INCLUDE_DIRS})
-link_directories(${CHECK_LIBRARY_DIRS})
-
 #-----------------------------------------------------------------------
 # Build the test cases
 
-macro(make_test test_name)
-    add_executable(${test_name} ${test_name}.c)
-    target_link_libraries(${test_name} ${CHECK_LDFLAGS} libbowsprit)
-    add_test(${test_name} ${test_name})
-endmacro(make_test)
-
-make_test(test-periodic)
-make_test(test-stats)
+add_c_test(test-periodic)
+add_c_test(test-stats)
 
 #-----------------------------------------------------------------------
 # Command-line tests


### PR DESCRIPTION
We now use the C template's helper macros to define our libraries and executables, which brings in support for building static libraries and for overriding the location of our prereqs.