### PR TITLE
Use all LDFLAGS when linking with check

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------
-# Copyright © 2011-2014, RedJack, LLC.
+# Copyright © 2011-2015, RedJack, LLC.
 # All rights reserved.
 #
 # Please see the COPYING file in this distribution for license details.
@@ -23,7 +23,7 @@ link_directories(${CHECK_LIBRARY_DIRS})
 
 macro(make_test test_name)
     add_executable(${test_name} ${test_name}.c)
-    target_link_libraries(${test_name} ${CHECK_LIBRARIES} libbowsprit)
+    target_link_libraries(${test_name} ${CHECK_LDFLAGS} libbowsprit)
     add_test(${test_name} ${test_name})
 endmacro(make_test)
 


### PR DESCRIPTION
The Ubuntu pkgconfig file for check includes a `-pthread` switch, which cmake doesn't pass through if we use the `_LIBRARIES` variable instead of the `_LDFLAGS` variable.