### PR TITLE
Fix incorrect size when freeing context

### DIFF
--- a/src/libbowsprit/stats.c
+++ b/src/libbowsprit/stats.c
@@ -278,7 +278,7 @@ bws_ctx_free(struct bws_ctx *pctx)
         bws_plugin_priv_free(curr);
     }
     cork_strfree(ctx->public.hostname);
-    cork_delete(struct bws_ctx, ctx);
+    cork_delete(struct bws_ctx_priv, ctx);
 }
 
 struct bws_plugin *


### PR DESCRIPTION
The libcork allocation API requires us to pass in the size of a struct whenever we free it, which must match the size that was used to allocate the struct.  I didn't have the right size for the `bws_ctx` destructor.